### PR TITLE
Generate typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A lightweight JWT implementation with ZERO dependencies for Cloudflare Worker",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "declarations": "tsc"
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/tsndr/cloudflare-worker-jwt/issues"
   },
-  "homepage": "https://github.com/tsndr/cloudflare-worker-jwt#readme"
+  "homepage": "https://github.com/tsndr/cloudflare-worker-jwt#readme",
+  "devDependencies": {
+    "typescript": "^4.2.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "declarations": "tsc"
+    "tsc": "tsc"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "allowJs": true,
+    "declaration": true,
+    "outDir": "./",
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true
+  },
+  "files": [
+    "index.js"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "target": "ES6",
+    "module": "ES6",
     "allowJs": true,
     "declaration": true,
     "outDir": "./",


### PR DESCRIPTION
Before publishing, the `tsc` command needs to be executed, or the `declarations` script in `package.json`. This will generate a `index.d.ts` file in the root folder of the repository.

I've tested with manually copying the generated d.ts file into the correct node_modules folder in my project, at it seems to work nicely in my environment.