### PR TITLE
Fix constructor error

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ class Base64URL {
 
 class JWT {
     constructor() {
-        if (!crypto || !crypto.subtle)
+        if (typeof crypto === 'undefined' || !crypto.subtle)
             throw new Error('Crypto not supported!')
         this.algorithms = {
             ES256: { name: 'ECDSA', namedCurve: 'P-256', hash: { name: 'SHA-256' } },


### PR DESCRIPTION
Update the constructor so that it reaches the `Crypto not supported` error and throws it as expected.