### PR TITLE
Add support for JWT header

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ type JWTAlgorithm = 'ES256' | 'ES384' | 'ES512' | 'HS256' | 'HS384' | 'HS512' | 
 type JWTSignOptions = {
     algorithm?: JWTAlgorithm,
     keyid?: string
+    header?: object
 }
 
 type JWTVerifyOptions = {

--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ class JWT {
             return null
         }
     }
-    async sign(payload, secret, options = { algorithm: 'HS256' }) {
+    async sign(payload, secret, options = { algorithm: 'HS256', header: { typ: 'JWT' } }) {
         if (typeof options === 'string')
-            options = { algorithm: options }
+            options = { algorithm: options, header: { typ: 'JWT' } }
         if (payload === null || typeof payload !== 'object')
             throw new Error('payload must be an object')
         if (typeof secret !== 'string')
@@ -67,7 +67,7 @@ class JWT {
             throw new Error('algorithm not found')
         payload.iat = Math.floor(Date.now() / 1000)
         const payloadAsJSON = JSON.stringify(payload)
-        const partialToken = `${Base64URL.stringify(this._utf8ToUint8Array(JSON.stringify({ alg: options.algorithm, kid: options.keyid })))}.${Base64URL.stringify(this._utf8ToUint8Array(payloadAsJSON))}`
+        const partialToken = `${Base64URL.stringify(this._utf8ToUint8Array(JSON.stringify({ ...options.header, alg: options.algorithm, kid: options.keyid })))}.${Base64URL.stringify(this._utf8ToUint8Array(payloadAsJSON))}`
         let keyFormat = 'raw'
         let keyData
         if (secret.startsWith('-----BEGIN')) {


### PR DESCRIPTION
A very simple implementation of JWT headers.

For some context, the JWT library I was using to verify JWTs made with this library was treating them as invalid because they were missing the `"typ": "JWT"` field in the header.