### PR TITLE
Destructure payload from decode function properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class JWT {
         const importAlgorithm = this.algorithms[options.algorithm]
         if (!importAlgorithm)
             throw new Error('algorithm not found')
-        const payload = this.decode(token)
+        const { payload } = this.decode(token)
         if (payload.nbf && payload.nbf > Math.floor(Date.now() / 1000)) {
             if (options.throwError)
                 throw 'NOT_YET_VALID'


### PR DESCRIPTION
The decode function returns an object containing a header and payload properties. Assigning the whole object to payload fails nbf and exp checks on verify JWT as those properties not found in decode return object directly. Instead, destructure payload property from decode return data that contains those values and check them correctly.
