### PR TITLE
docs: don't install as dev dependency (I think?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight JWT implementation with ZERO dependencies for Cloudflare Workers.
 ## Install
 
 ```
-npm i -D @tsndr/cloudflare-worker-jwt
+npm i @tsndr/cloudflare-worker-jwt
 ```
 
 


### PR DESCRIPTION
Think the installation command shouldn't use `-D` as it's used in the production code right, so installing as dev dep would be confusing, right?

Please correct me if I'm wrong 🙏

Also thanks a lot for this package, was just using for a way to sign and verify JWT in Pages ❤️