### PR TITLE
Allow array in Audience

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export interface JwtHeader {
  * @typedef JwtPayload
  * @prop {string} [iss] Issuer
  * @prop {string} [sub] Subject
- * @prop {string} [aud] Audience
+ * @prop {string | string[]} [aud] Audience
  * @prop {string} [exp] Expiration Time
  * @prop {string} [nbf] Not Before
  * @prop {string} [iat] Issued At
@@ -47,7 +47,7 @@ export interface JwtPayload {
     sub?: string
 
     /** Audience */
-    aud?: string
+    aud?: string | string[]
 
     /** Expiration Time */
     exp?: number


### PR DESCRIPTION
The Audience claim (`aud`) can be one or multiple values. See [4.1.3 in spec](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).

I've updated the typescript definitions to allow for this.