### PR TITLE
Fix UTF-8 Character Decoding in Base64 JWT Parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,8 +199,8 @@ async function importKey(key: string | JsonWebKey, algorithm: SubtleCryptoImport
 function decodePayload<T = any>(raw: string): T | undefined {
     try {
         const binaryString = atob(raw)
-        const encodedString = encodeURIComponent(binaryString).replace(/%([0-9A-F]{2})/g, (match, p1) => {
-          return String.fromCharCode('0x' + p1);
+        const encodedString = encodeURIComponent(binaryString).replace(/%([0-9A-F]{2})/g, (_match, p1) => {
+          return String.fromCharCode(parseInt(p1, 16));
         });
 
         return JSON.parse(decodeURIComponent(encodedString));

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,11 +199,15 @@ async function importKey(key: string | JsonWebKey, algorithm: SubtleCryptoImport
 function decodePayload<T = any>(raw: string): T | undefined {
     try {
         const binaryString = atob(raw)
-        const encodedString = encodeURIComponent(binaryString).replace(/%([0-9A-F]{2})/g, (_match, p1) => {
-          return String.fromCharCode(parseInt(p1, 16));
-        });
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+        }
 
-        return JSON.parse(decodeURIComponent(encodedString));
+        const decoder = new TextDecoder('utf-8');
+        const decodedString = decoder.decode(bytes);
+
+        return JSON.parse(decodedString);
     } catch {
         return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,12 @@ async function importKey(key: string | JsonWebKey, algorithm: SubtleCryptoImport
 
 function decodePayload<T = any>(raw: string): T | undefined {
     try {
-        return JSON.parse(atob(raw))
+        const binaryString = atob(raw)
+        const encodedString = encodeURIComponent(binaryString).replace(/%([0-9A-F]{2})/g, (match, p1) => {
+          return String.fromCharCode('0x' + p1);
+        });
+
+        return JSON.parse(decodeURIComponent(encodedString));
     } catch {
         return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,14 +198,8 @@ async function importKey(key: string | JsonWebKey, algorithm: SubtleCryptoImport
 
 function decodePayload<T = any>(raw: string): T | undefined {
     try {
-        const binaryString = atob(raw)
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-        }
-
-        const decoder = new TextDecoder('utf-8');
-        const decodedString = decoder.decode(bytes);
+        const bytes = Array.from(atob(raw), char => char.charCodeAt(0));
+        const decodedString = new TextDecoder('utf-8').decode(new Uint8Array(bytes));
 
         return JSON.parse(decodedString);
     } catch {


### PR DESCRIPTION
close #58

I have implemented the use of TextDecoder for base64 decoding, which allows for accurate decoding of strings containing multibyte characters like ("🐬").