### PR TITLE
Fix typing to make build work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ export async function sign<Payload = {}, Header = {}>(payload: JwtPayload<Payloa
     if (typeof options === 'string')
         options = { algorithm: options }
 
-    options = { algorithm: 'HS256', header: { typ: 'JWT' }, ...options }
+    options = { algorithm: 'HS256', header: { typ: 'JWT' } as JwtHeader<Header>, ...options }
 
     if (!payload || typeof payload !== 'object')
         throw new Error('payload must be an object')


### PR DESCRIPTION
If we run `npm run build` from latest commit, we'll receive following error menages:


```
npm run build

> @tsndr/cloudflare-worker-jwt@2.3.2 build
> tsc

src/index.ts:223:37 - error TS2322: Type '{ typ: string; }' is not assignable to type 'JwtHeader<Header>'.
  Type '{ typ: string; }' is not assignable to type 'Header'.
    'Header' could be instantiated with an arbitrary type which could be unrelated to '{ typ: string; }'.

223     options = { algorithm: 'HS256', header: { typ: 'JWT' }, ...options }
                                        ~~~~~~

src/index.ts:231:24 - error TS2339: Property 'algorithm' does not exist on type 'JwtAlgorithm | JwtSignOptions<Header>'.
  Property 'algorithm' does not exist on type '"ES256"'.

231     if (typeof options.algorithm !== 'string')
                           ~~~~~~~~~

src/index.ts:234:74 - error TS2339: Property 'algorithm' does not exist on type 'JwtAlgorithm | JwtSignOptions<Header>'.
  Property 'algorithm' does not exist on type '"ES256"'.

234     const algorithm: SubtleCryptoImportKeyAlgorithm = algorithms[options.algorithm]
                                                                             ~~~~~~~~~

src/index.ts:242:73 - error TS2339: Property 'header' does not exist on type 'JwtAlgorithm | JwtSignOptions<Header>'.
  Property 'header' does not exist on type '"ES256"'.

242     const partialToken = `${textToBase64Url(JSON.stringify({ ...options.header, alg: options.algorithm }))}.${textToBase64Url(JSON.stringify(payload))}`
                                                                            ~~~~~~

src/index.ts:242:94 - error TS2339: Property 'algorithm' does not exist on type 'JwtAlgorithm | JwtSignOptions<Header>'.
  Property 'algorithm' does not exist on type '"ES256"'.

242     const partialToken = `${textToBase64Url(JSON.stringify({ ...options.header, alg: options.algorithm }))}.${textToBase64Url(JSON.stringify(payload))}`
                                                                                                 ~~~~~~~~~


Found 5 errors in the same file, starting at: src/index.ts:223
```

This error was introduced in #56, and maybe @Le0Developer could suggest a better fix?