### PR TITLE
Fix unicode payload signing

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -73,6 +73,11 @@ const payload: Payload = {
     name: "John Doe",
 }
 
+const unicodePayload: Payload = {
+    sub: "1234567890",
+    name: "John Doe 😎",
+}
+
 describe.each(Object.entries(data) as [JwtAlgorithm, Dataset][])('%s', (algorithm, data) => {
     let token = ''
 
@@ -94,6 +99,11 @@ describe.each(Object.entries(data) as [JwtAlgorithm, Dataset][])('%s', (algorith
 
     test('sign internal', async () => {
         token = await jwt.sign<Payload>(payload, data.private, algorithm)
+        expect(token).toMatch(/^[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+$/)
+    })
+
+    test('sign unciode', async () => {
+        token = await jwt.sign<Payload>(unicodePayload, data.private, algorithm)
         expect(token).toMatch(/^[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+$/)
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,10 @@ function base64UrlToArrayBuffer(b64url: string): ArrayBuffer {
 }
 
 function textToBase64Url(str: string): string {
-    return btoa(str).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+    const encoder = new TextEncoder();
+    const charCodes = encoder.encode(str);
+    const binaryStr = String.fromCharCode(...charCodes);
+    return btoa(binaryStr).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 function pemToBinary(pem: string): ArrayBuffer {


### PR DESCRIPTION
In the recent version of cloudflare-worker-jwt (specifically, after commit 6b3192b4b91cd5880c77d1ded75a1a9550d5d597), if we encode payload with any Unicode character, it will throw `InvalidCharacterError: Invalid character`.