### PR TITLE
Fix types issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { SubtleCryptoImportKeyAlgorithm } from "@cloudflare/workers-types"
 import {
     textToArrayBuffer,
     arrayBufferToBase64Url,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { SubtleCryptoImportKeyAlgorithm } from "@cloudflare/workers-types"
+
 export type KeyUsages = "sign" | "verify"
 
 export function bytesToByteString(bytes: Uint8Array): string {


### PR DESCRIPTION
Awesome library here!

My code threw linting errors from this package, because `SubtleCryptoImportKeyAlgorithm` wasn't defined. I looked at the tsconfig, and the types were added incorrectly. This fixes that, by just adding the version to cloudflare types.